### PR TITLE
Adding github action for automated submission and dependabot upkeep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: daily
+      open-pull-requests-limit: 10

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,28 @@
+name: automerge
+on: [push, pull_request]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: "14.x"
+
+            - name: Install dependencies
+              run: npm install
+            - name: Build
+              run: npx gulp build
+    automerge:
+        needs: build
+        runs-on: ubuntu-latest
+
+        permissions:
+            pull-requests: write
+            contents: write
+
+        steps:
+            - uses: fastify/github-action-merge-dependabot@v3.0.0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,23 @@
+name: Submit
+
+on:
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag to submit, i.e 0.4.3"
+                required: true
+
+jobs:
+    submit:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download Github Release Assets
+              uses: plasmo-corp/download-release-asset@v1.0.0
+              with:
+                  files: Archive-*
+                  tag: ${{ github.event.inputs.tag }}
+            - name: Browser Plugin Publish
+              uses: plasmo-corp/bpp@v1
+              with:
+                  artifact: "Archive-${{ github.event.inputs.tag }}.zip"
+                  keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.zip
 extra/archives/
 node_modules/
+keys.json


### PR DESCRIPTION
Hi @vict0rsch!

Love PaperMemory!!! It makes note taking on arxiv to another level. I'm spreading it to my friends :D Also, I was looking for ways to contribute, and found that since your codebase doesn't have automated ci, I thought adding that might be helpful. 

First, I added a dependabot config for you so it should bump dependencies version automatically. Then, I created 2 workflows in this PR:

- `automerge`: automate the dependabot merging to reduce PR noise, using https://github.com/fastify/github-action-merge-dependabot
- `submit`: automate the zip submission process to the Chrome/Firefox/Edge stores automatically, using [bpp](https://browser.market) . It is set to run manually from the github action tab, but we can tweak it to run as frequent as you wish! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

The `SUBMIT_KEYS` secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample key for you:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
	"firefox": {
		"apiKey": "123",
		"apiSecret": "789",
		"extId": "abcd"
	}
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)