### PR TITLE
Upgrade bpp to v2

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -12,12 +12,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Download Github Release Assets
-              uses: plasmo-corp/download-release-asset@v1.0.0
+              uses: PlasmoHQ/download-release-asset@v1.0.0
               with:
                   files: Archive-*
                   tag: ${{ github.event.inputs.tag }}
             - name: Browser Plugin Publish
-              uses: plasmo-corp/bpp@v1
+              uses: PlasmoHQ/bpp@v2
               with:
                   artifact: "Archive-${{ github.event.inputs.tag }}.zip"
                   keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Upgrades the Browser Plugin Publish Github action to v2. We also renamed our organization which is why that's different now!

The new version adds support for the Edge Web Store Add-Ons API and improved reliability.


⚠️ Heads up the schema's changed a bit ⚠️

Here's an updated representation: https://raw.githubusercontent.com/PlasmoHQ/bpp/v2/keys.schema.json
Here's an example: https://github.com/PlasmoHQ/bpp/blob/main/keys.template.json
