### PR TITLE
Fix bugs and harden against XSS across the extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Build Extension
+        run: npm run build:chrome
+
       - uses: nick-fields/retry@v3
         name: Run Test
         with:
@@ -58,6 +61,9 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
+
+      - name: Build Extension
+        run: npm run build:chrome
 
       - uses: nick-fields/retry@v3
         name: Run Storage Test

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -87,7 +87,9 @@ export function initBackground() {
     // Remove DOM-dependent setFaviconCode since it's not needed in service worker
 
     const fetchOpenReviewNoteJSON = async (url) => {
-        const id = url.match(/id=([\w-]+)/)[1];
+        const match = url.match(/id=([\w-]+)/);
+        if (!match) return;
+        const id = match[1];
         const api = `https://api.openreview.net/notes?id=${id}`;
         let response = await fetch(api);
         let json = await response.json();
@@ -101,7 +103,9 @@ export function initBackground() {
     };
 
     const fetchOpenReviewForumJSON = async (url) => {
-        const id = url.match(/id=([\w-]+)/)[1];
+        const match = url.match(/id=([\w-]+)/);
+        if (!match) return;
+        const id = match[1];
         const api = `https://api.openreview.net/notes?forum=${id}`;
         let response = await fetch(api);
         let json = await response.json();

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -337,6 +337,9 @@ export function initBackground() {
     };
 
     chrome.runtime.onMessage.addListener((payload, sender, sendResponse) => {
+        if (sender.id !== chrome.runtime.id) {
+            return;
+        }
         if (payload.type === "update-title") {
             const { title, url } = payload.options;
             paperTitles[url] = title.replaceAll('"', "'");
@@ -357,12 +360,15 @@ export function initBackground() {
                     });
                 }
                 const safeTitle = payload.title
-                    .replaceAll("?", "")
-                    .replaceAll(":", "")
-                    .replaceAll("..", "")
-                    .replaceAll("/", "_")
-                    .replaceAll("\\", "_");
+                    .replace(/[<>:"/\\|?*\x00-\x1f]/g, "_")
+                    .replace(/\.{2,}/g, ".")
+                    .replace(/^\.+|\.+$/g, "")
+                    .slice(0, 200);
                 const filename = "PaperMemoryStore/" + safeTitle;
+                if (!/^https?:\/\//.test(payload.pdfUrl)) {
+                    sendResponse(false);
+                    return;
+                }
                 chrome.downloads.download({ url: payload.pdfUrl, filename });
                 sendResponse(true);
             });

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -87,7 +87,7 @@ export function initBackground() {
     // Remove DOM-dependent setFaviconCode since it's not needed in service worker
 
     const fetchOpenReviewNoteJSON = async (url) => {
-        const id = url.match(/id=([\w-])+/)[0].replace("id=", "");
+        const id = url.match(/id=([\w-]+)/)[1];
         const api = `https://api.openreview.net/notes?id=${id}`;
         let response = await fetch(api);
         let json = await response.json();
@@ -101,7 +101,7 @@ export function initBackground() {
     };
 
     const fetchOpenReviewForumJSON = async (url) => {
-        const id = url.match(/id=([\w-])+/)[0].replace("id=", "");
+        const id = url.match(/id=([\w-]+)/)[1];
         const api = `https://api.openreview.net/notes?forum=${id}`;
         let response = await fetch(api);
         let json = await response.json();
@@ -161,29 +161,8 @@ export function initBackground() {
     };
 
     const fetchPWCData = async (arxivId, title) => {
-        return; // PWC API discontinued, to fix later
-        let pwcPath = `https://paperswithcode.com/api/v1/papers/?`;
-        if (arxivId) {
-            log("Fetching PWC data for arxivId:", arxivId);
-            pwcPath += new URLSearchParams({ arxiv_id: arxivId });
-        } else if (title) {
-            log("Fetching PWC data for paper:", title);
-            pwcPath += new URLSearchParams({ title });
-        }
-        const response = await fetch(pwcPath);
-        try {
-            const json = await response.json();
-        } catch (error) {
-            logError("[fetchPWCData]", error);
-            return;
-        }
-
-        if (json["count"] !== 1) {
-            log("No PWC entry match.");
-            return;
-        }
-        log("PWC entry match:", json["results"][0]["id"]);
-        return json["results"][0];
+        // PWC API discontinued, to fix later
+        return;
     };
 
     const findCodesForPaper = async (request) => {
@@ -323,7 +302,6 @@ export function initBackground() {
 
     const pushSyncPapers = async () => {
         if (!(await shouldSync())) return;
-        const identifier = await getIdentifier();
         try {
             const start = Date.now();
             consoleHeader(`Pushing ${String.fromCodePoint("0x23EB")}`);
@@ -434,11 +412,10 @@ export function initBackground() {
                     console.log(">>> Setting tab title to :", paperTitle);
                     chrome.scripting.executeScript({
                         target: { tabId },
-                        code: `
-                        ${setTitleCode(paperTitle)};
-                        ${setFaviconCode};
-                    `,
-                        runAt: "document_start",
+                        func: (title) => {
+                            document.title = title;
+                        },
+                        args: [paperTitle],
                     });
                 }
             }

--- a/src/bibMatcher/bibMatcher.js
+++ b/src/bibMatcher/bibMatcher.js
@@ -9,7 +9,7 @@ import {
     hideId,
     querySelector,
 } from "@pmu/miniquery.js";
-import { copyTextToClipboard } from "@pmu/functions.js";
+import { copyTextToClipboard, escapeHtml } from "@pmu/functions.js";
 import { BibtexParser, bibtexToObject, bibtexToString } from "@pmu/bibtexParser.js";
 import {
     tryDBLP,
@@ -313,7 +313,7 @@ const matchItems = async (papersToMatch) => {
         setHTML("matching-status-index", idx + 1);
         setHTML(
             "matching-status-title",
-            paper.title.replaceAll("{", "").replaceAll("}", ""),
+            escapeHtml(paper.title.replaceAll("{", "").replaceAll("}", "")),
         );
         changeProgress(parseInt((idx / papersToMatch.length) * 100));
 
@@ -365,10 +365,10 @@ const updateMatchedTitles = (matchedBibtexStrs, sources, venues) => {
         for (const [idx, title] of titles.entries()) {
             htmls.push(
                 `<tr>
-                    <th class="match-citation-key">${keys[idx]}</th>
-                    <th class='match-title'>${title}</th>
-                    <th class="match-venue">${venues[idx]}</th>
-                    <th class="match-source">${sources[idx]}</th>
+                    <th class="match-citation-key">${escapeHtml(keys[idx])}</th>
+                    <th class='match-title'>${escapeHtml(title)}</th>
+                    <th class="match-venue">${escapeHtml(venues[idx])}</th>
+                    <th class="match-source">${escapeHtml(sources[idx])}</th>
                 </tr>`,
             );
         }

--- a/src/content_scripts/content_script.js
+++ b/src/content_scripts/content_script.js
@@ -448,7 +448,8 @@ const contentScriptMain = async ({
             if (!state.papers.hasOwnProperty(id)) return;
             const paper = state.papers[id];
             const maxWait = 60 * 1000;
-            while (1) {
+            const maxIters = 20;
+            while (PDF_TITLE_ITERS < maxIters) {
                 const waitTime = Math.min(maxWait, 250 * 2 ** PDF_TITLE_ITERS);
                 await sleep(waitTime);
                 document.title = "";

--- a/src/content_scripts/content_script.js
+++ b/src/content_scripts/content_script.js
@@ -19,6 +19,7 @@ import {
     sendMessageToBackground,
     downloadURI,
     dummyEvent,
+    escapeHtml,
 } from "@pmu/functions.js";
 import { bibtexToString, bibtexToObject } from "@pmu/bibtexParser.js";
 import {
@@ -254,8 +255,8 @@ const makePaperMemoryHTMLDiv = (paper) => {
                 style="display: flex; justify-content: center; align-items: center;" 
                 id="pm-venue"
             >
-                <span id="pm-venue-name">${paper.venue}</span>
-                <span id="pm-venue-year">${bibtexToObject(paper.bibtex).year}</span>
+                <span id="pm-venue-name">${escapeHtml(paper.venue)}</span>
+                <span id="pm-venue-year">${escapeHtml(bibtexToObject(paper.bibtex).year)}</span>
             </div>
             <p
                 style="text-align: center; font-size: 12px; color: #666; margin: 0;"
@@ -609,8 +610,8 @@ const displayPaperVenue = (paper) => {
     const venueDiv = /*html*/ `
         <div id="pm-publication-wrapper">
             <div id="pm-publication-venue">
-                <span id="pm-venue-name">${paper.venue}</span>
-                <span id="pm-venue-year">${bibtexToObject(paper.bibtex).year}</span>
+                <span id="pm-venue-name">${escapeHtml(paper.venue)}</span>
+                <span id="pm-venue-year">${escapeHtml(bibtexToObject(paper.bibtex).year)}</span>
             </div>
         </div>`;
     findEl({ element: "pm-publication-wrapper" })?.remove();
@@ -628,9 +629,11 @@ const displayPaperCode = (paper) => {
     if (!paper.codeLink) {
         return;
     }
+    const safeLink = /^https?:\/\//.test(paper.codeLink) ? escapeHtml(paper.codeLink) : "";
+    if (!safeLink) return;
     const code = /*html*/ `
         <div id="pm-code">
-        <h3>Code:</h3> <a id="pm-code-link" href="${paper.codeLink}">${paper.codeLink}</a>
+        <h3>Code:</h3> <a id="pm-code-link" href="${safeLink}">${safeLink}</a>
         </div>
     `;
     findEl({ element: "pm-code" })?.remove();
@@ -649,8 +652,8 @@ const huggingfacePapers = (paper, url) => {
     const venueDiv = /*html*/ `
         <div id="pm-publication-wrapper">
             <div id="pm-publication-venue">
-                <span id="pm-venue-name">${paper.venue}</span>
-                <span id="pm-venue-year">${bibtexToObject(paper.bibtex).year}</span>
+                <span id="pm-venue-name">${escapeHtml(paper.venue)}</span>
+                <span id="pm-venue-year">${escapeHtml(bibtexToObject(paper.bibtex).year)}</span>
                 <span id="pm-hf-label">(PaperMemory)</span>
             </div>
         </div>`;
@@ -853,7 +856,7 @@ const updateCompleteSecretHTML = (paper) => {
                 .querySelector("head")
                 .insertAdjacentHTML(
                     "beforeend",
-                    /*html*/ `<meta name="pm-complete-secret-html" content="${paper.id}">`,
+                    /*html*/ `<meta name="pm-complete-secret-html" content="${escapeHtml(paper.id)}">`,
                 );
         }
     }, 50);

--- a/src/content_scripts/content_script.js
+++ b/src/content_scripts/content_script.js
@@ -653,7 +653,7 @@ const huggingfacePapers = (paper, url) => {
                 <span id="pm-hf-label">(PaperMemory)</span>
             </div>
         </div>`;
-    abstractH2 = queryAll("h2").find((h) => h.innerText.trim() === "Abstract");
+    const abstractH2 = queryAll("h2").find((h) => h.innerText.trim() === "Abstract");
     if (!abstractH2) {
         log("Missing 'Abstract' h2 title on HuggingFace paper page.");
     }

--- a/src/content_scripts/content_script.js
+++ b/src/content_scripts/content_script.js
@@ -136,7 +136,6 @@ $.extend($.easing, {
     },
 });
 
-var PDF_TITLE_ITERS = 0;
 
 /**
  * Centralizes HTML svg codes
@@ -450,12 +449,13 @@ const contentScriptMain = async ({
             const paper = state.papers[id];
             const maxWait = 60 * 1000;
             const maxIters = 20;
-            while (PDF_TITLE_ITERS < maxIters) {
-                const waitTime = Math.min(maxWait, 250 * 2 ** PDF_TITLE_ITERS);
+            let pdfTitleIters = 0;
+            while (pdfTitleIters < maxIters) {
+                const waitTime = Math.min(maxWait, 250 * 2 ** pdfTitleIters);
                 await sleep(waitTime);
                 document.title = "";
                 document.title = paper.title;
-                PDF_TITLE_ITERS++;
+                pdfTitleIters++;
             }
         };
         makeTitle(id);
@@ -660,6 +660,7 @@ const huggingfacePapers = (paper, url) => {
     const abstractH2 = queryAll("h2").find((h) => h.innerText.trim() === "Abstract");
     if (!abstractH2) {
         log("Missing 'Abstract' h2 title on HuggingFace paper page.");
+        return;
     }
     const authorDiv = abstractH2.parentElement.previousElementSibling;
     log("Adding venue to HuggingFace paper page.");

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -32,6 +32,7 @@ import {
     cleanPapers,
     sendMessageToBackground,
     parseTags,
+    escapeHtml,
 } from "@pmu/functions.js";
 import {
     makePaper,
@@ -248,7 +249,7 @@ const handleParseImportJson = async (e) => {
                 if (!Object.values(is).some((i) => i)) {
                     feedback.innerHTML += `<li>[${
                         i + 1
-                    }]&nbsp; &times;&nbsp; Error: ${url} does not come from a known source</li>`;
+                    }]&nbsp; &times;&nbsp; Error: ${escapeHtml(url)} does not come from a known source</li>`;
                     warn("Aborting.");
                 } else {
                     let paper;
@@ -266,12 +267,12 @@ const handleParseImportJson = async (e) => {
                     if (exists) {
                         feedback.innerHTML += `<li>[${
                             i + 1
-                        }]&nbsp; &times;&nbsp; Warning: ${url} already exists and has been ignored</li>`;
+                        }]&nbsp; &times;&nbsp; Warning: ${escapeHtml(url)} already exists and has been ignored</li>`;
                         warn("Aborting.");
                     } else {
                         feedback.innerHTML += `<li>[${
                             i + 1
-                        }]&nbsp; &#10004; ${url} has been successfully added to your Memory!</li>`;
+                        }]&nbsp; &#10004; ${escapeHtml(url)} has been successfully added to your Memory!</li>`;
                     }
                 }
             } catch (error) {
@@ -279,7 +280,7 @@ const handleParseImportJson = async (e) => {
                 warn("Aborting.");
                 feedback.innerHTML += `<li>[${
                     i + 1
-                }]&nbsp; &times;&nbsp; Error: ${url} (open the JavaScript Console for more info)</li>`;
+                }]&nbsp; &times;&nbsp; Error: ${escapeHtml(url)} (open the JavaScript Console for more info)</li>`;
             }
         }
         await pushToRemote();
@@ -348,13 +349,13 @@ const getAutoTagHTML = (at) => {
     return /*html*/ `
     <div class="row auto-tags-item" id="auto-tags-item--${id}">
         <div class="col-3">
-            <input type="text" id="auto-tags-item-title--${id}" value="${title}" />
+            <input type="text" id="auto-tags-item-title--${id}" value="${escapeHtml(title)}" />
         </div>
         <div class="col-3">
-            <input type="text" id="auto-tags-item-authors--${id}" value="${authors}" />
+            <input type="text" id="auto-tags-item-authors--${id}" value="${escapeHtml(authors)}" />
         </div>
         <div class="col-3">
-            <input type="text" id="auto-tags-item-tags--${id}" value="${tags}" />
+            <input type="text" id="auto-tags-item-tags--${id}" value="${escapeHtml(tags)}" />
         </div>
         <div class="col-3">
             <div class="row">
@@ -496,14 +497,14 @@ const addPreprintUpdate = (update) => {
     for (const [k, v] of Object.entries(update)) {
         if (k !== "paper" && k !== "bibtex") {
             if (v) {
-                contents.push(`<span>${k}:</span>&nbsp;<span>${v}</span>`);
+                contents.push(`<span>${escapeHtml(k)}:</span>&nbsp;<span>${escapeHtml(v)}</span>`);
             }
         }
     }
     contents = contents.join("<br>");
     const html = /*html*/ `
     <div class="paper-update-item" id="paper-update-item--${paper.id}">
-        <h4>${paper.title}</h4>
+        <h4>${escapeHtml(paper.title)}</h4>
         <div>
             <div class="preprint-update-contents">
                 <div>Updates to approve:</div>
@@ -555,7 +556,7 @@ const startMatching = async (papersToMatch) => {
     for (const [idx, paper] of papersToMatch.entries()) {
         console.log("idx: ", idx);
         setHTML("matching-status-index", idx + 1);
-        setHTML("matching-status-title", paper.title);
+        setHTML("matching-status-title", escapeHtml(paper.title));
         changeProgress(parseInt((idx / papersToMatch.length) * 100));
 
         var bibtex, venue, note, code, match;
@@ -1092,7 +1093,7 @@ const setupSync = async () => {
                 }
             }
         } catch (e) {
-            setHTML("overwriteRemoteFeedback", e);
+            setHTML("overwriteRemoteFeedback", escapeHtml(String(e)));
         }
         await sendMessageToBackground({ type: "restartGist" });
         hideId("sync-loader");

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -140,7 +140,7 @@ const handleSelectImportJson = () => {
     findEl({ element: "import-json-papers-button" }).disabled = false;
 };
 
-const validateImportPaper = (p) => {
+const validateImportPaper = (p, i) => {
     if (typeof p === "string") {
         if (!isValidHttpUrl(p)) {
             alert(`${p} (entry ${i}) is not a valid URL`);
@@ -213,7 +213,7 @@ const handleParseImportJson = async (e) => {
                 throw new Error("The JSON file must contain a *list* of papers");
             }
             for (const [i, p] of papersToParse.entries()) {
-                if (!validateImportPaper(p)) {
+                if (!validateImportPaper(p, i)) {
                     return;
                 }
             }
@@ -561,7 +561,7 @@ const startMatching = async (papersToMatch) => {
         var bibtex, venue, note, code, match;
 
         setHTML("matching-status-provider", "paperswithcode.org ...");
-        pwcMatch = await tryPWCMatch(paper);
+        const pwcMatch = await tryPWCMatch(paper);
         console.log("pwcMatch: ", pwcMatch);
         code = !paper.codeLink && pwcMatch?.url;
         note = !paper.note && pwcMatch?.note;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -949,7 +949,7 @@ const setupSync = async () => {
             const { file, pat, gistId } = payload;
             log("Gist ID", gistId);
             log("Data URL", file.raw_url);
-            log("Personal Access Token", pat);
+            log("Personal Access Token", "[REDACTED]");
             setHTML("pat-feedback", "Ok! Token is valid.");
             toggleSync();
         }

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -919,7 +919,7 @@ const setupSync = async () => {
 
     if (!ok) {
         if (error) {
-            setHTML("pat-feedback", "Invalid PAT" + "<br/><br/>" + error);
+            setHTML("pat-feedback", "Invalid PAT" + "<br/><br/>" + escapeHtml(String(error)));
         }
         hideId("pat-loader");
         await toggleSync({ hideAll: true });
@@ -944,7 +944,7 @@ const setupSync = async () => {
         const { ok, payload, error } = await getGist({ pat });
         if (!ok) {
             logError(error);
-            setHTML("pat-feedback", error.response.data.message);
+            setHTML("pat-feedback", escapeHtml(String(error.response.data.message)));
         } else {
             const { file, pat, gistId } = payload;
             log("Gist ID", gistId);

--- a/src/popup/js/templates.js
+++ b/src/popup/js/templates.js
@@ -1,6 +1,6 @@
 // ES Module imports
 import { state, knownPaperPages, svgActionsHoverTitles } from "@pmu/config.js";
-import { getDisplayId, tablerSvg, isPdfUrl, cutAuthors } from "@pmu/functions.js";
+import { getDisplayId, tablerSvg, isPdfUrl, cutAuthors, escapeHtml } from "@pmu/functions.js";
 import { getTagsOptions } from "@pmu/state.js";
 import { isPaper } from "@pmu/paper.js";
 /**
@@ -53,7 +53,7 @@ export const getMemoryItemHTML = (paper) => {
     const favoriteClass = paper.favorite ? "favorite" : "";
     const titles = { ...svgActionsHoverTitles };
     // titles behave differently in build/watch mode. This works in build
-    titles.pdfLink = `Open tab to ${paper.title}`;
+    titles.pdfLink = `Open tab to ${escapeHtml(paper.title)}`;
     titles.copyLink = `Copy URL to the paper's ${
         state.prefs.checkPreferPdf ? "PDF" : "abstract"
     }`;
@@ -62,7 +62,7 @@ export const getMemoryItemHTML = (paper) => {
         <small class="memory-item-faded">
 
             <div class="memory-code-link"> ${
-                paper.codeLink.replace(/^https?:\/\//, "") || ""
+                escapeHtml(paper.codeLink.replace(/^https?:\/\//, "") || "")
             } </div>
             <div class="memory-website-url">
                 ${
@@ -78,7 +78,7 @@ export const getMemoryItemHTML = (paper) => {
         noteDiv = /*html*/ `
             <div class="memory-note-div memory-item-faded">
                 <span class="note-content-header">Note:</span>
-                <span class="note-content">${note}</span>
+                <span class="note-content">${escapeHtml(note)}</span>
             </div>
         `;
     }
@@ -163,7 +163,7 @@ export const getMemoryItemHTML = (paper) => {
                         favoriteClass,
                     ])}
                 </span>
-                ${paper.title}
+                ${escapeHtml(paper.title)}
                 <div class="title-tooltip" style="display: none;">
                     ${titleInfoTable}
                 </div>
@@ -171,7 +171,7 @@ export const getMemoryItemHTML = (paper) => {
             <div class="my-1 mx-0">
                 <small class="tag-list">
                     ${[...tags]
-                        .map((t) => `<span class="memory-tag" >${t}</span>`)
+                        .map((t) => `<span class="memory-tag" >${escapeHtml(t)}</span>`)
                         .join("")}
                 </small>
                 <div class="edit-tags p-0" style="display: none">
@@ -187,7 +187,7 @@ export const getMemoryItemHTML = (paper) => {
                     </div>
                 </div>
             </div>
-            <small class="memory-authors">${cutAuthors(paper.author)}</small>
+            <small class="memory-authors">${cutAuthors(escapeHtml(paper.author))}</small>
 
             <div class="code-and-note">${codeDiv} ${noteDiv}</div>
 
@@ -256,7 +256,7 @@ export const getMemoryItemHTML = (paper) => {
                             <input
                                 type="text"
                                 class="form-code-input"
-                                value="${paper.codeLink || ""}"
+                                value="${escapeHtml(paper.codeLink || "")}"
                                 placeholder="Add link"
                             />
                         </div>
@@ -267,7 +267,7 @@ export const getMemoryItemHTML = (paper) => {
                                 class="form-note-textarea"
                                 placeholder="Anything to note?"
                             >
-${note}</textarea
+${escapeHtml(note)}</textarea
                             >
                         </div>
                         <div class="form-note-buttons">
@@ -324,7 +324,7 @@ export const getPopupEditFormHTML = (paper) => {
                         id="popup-form-codeLink--${id}"
                         type="text"
                         class="form-code-input mt-0"
-                        value="${paper.codeLink || ""}"
+                        value="${escapeHtml(paper.codeLink || "")}"
                         placeholder="Add code link"
                     />
                 </div>
@@ -336,7 +336,7 @@ export const getPopupEditFormHTML = (paper) => {
                         id="popup-form-note-textarea--${id}"
                         placeholder="Anything to note?"
                     >
-${note}</textarea
+${escapeHtml(note)}</textarea
                     >
                 </div>
             </div>

--- a/src/popup/js/templates.js
+++ b/src/popup/js/templates.js
@@ -21,7 +21,7 @@ export const getPaperInfoTable = (paper) => {
     if (paper.venue)
         tableData.push([
             "Publication",
-            `<strong>${paper.venue} ${paper.year}</strong>`,
+            `<strong>${escapeHtml(paper.venue)} ${escapeHtml(String(paper.year))}</strong>`,
         ]);
     return /*html*/ `
         <table class="paper-info-table">

--- a/src/shared/js/utils/config.js
+++ b/src/shared/js/utils/config.js
@@ -6,7 +6,7 @@ import { miniHash } from "@pmu/functions.js";
 if (!Array.prototype.last) {
     Object.defineProperty(Array.prototype, "last", {
         value: function (i = 0) {
-            return this.reverse()[i];
+            return this[this.length - 1 - i];
         },
         configurable: true,
     });

--- a/src/shared/js/utils/data.js
+++ b/src/shared/js/utils/data.js
@@ -811,11 +811,15 @@ export const prepareOverwriteData = async (data) => {
         for (const id in papersToWrite) {
             if (!id.startsWith("__")) {
                 let paperWarnings = validatePaper(papersToWrite[id]).warnings;
-                if (paperWarnings && paperWarnings.length > 0) {
+                const hasWarnings = Object.values(paperWarnings).some(
+                    (v) => v.length > 0,
+                );
+                if (hasWarnings) {
                     warning +=
                         "<br/>" +
                         Object.entries(paperWarnings)
-                            .map((k, v) => `<h5>${k}</h5>${v.join("<br/>")}`)
+                            .filter(([, v]) => v.length > 0)
+                            .map(([k, v]) => `<h5>${k}</h5>${v.join("<br/>")}`)
                             .join("<br/>");
                 }
             }

--- a/src/shared/js/utils/data.js
+++ b/src/shared/js/utils/data.js
@@ -11,6 +11,7 @@ import {
     miniHash,
     parseUrl,
     stringifyError,
+    escapeHtml,
 } from "@pmu/functions.js";
 import {
     state,
@@ -819,7 +820,7 @@ export const prepareOverwriteData = async (data) => {
                         "<br/>" +
                         Object.entries(paperWarnings)
                             .filter(([, v]) => v.length > 0)
-                            .map(([k, v]) => `<h5>${k}</h5>${v.join("<br/>")}`)
+                            .map(([k, v]) => `<h5>${escapeHtml(k)}</h5>${v.map(escapeHtml).join("<br/>")}`)
                             .join("<br/>");
                 }
             }

--- a/src/shared/js/utils/data.js
+++ b/src/shared/js/utils/data.js
@@ -495,9 +495,9 @@ export const versionToSemantic = (dataVersionInt) => {
     // 209 -> 0.2.9
     // 1293 -> 0.12.93
     // 23439 -> 2.34.39
-    major = parseInt(dataVersionInt / 1e4, 10);
+    const major = parseInt(dataVersionInt / 1e4, 10);
     dataVersionInt -= major * 1e4;
-    minor = parseInt(dataVersionInt / 1e2, 10);
+    const minor = parseInt(dataVersionInt / 1e2, 10);
     dataVersionInt -= minor * 1e2;
     return `${major}.${minor}.${dataVersionInt}`;
 };

--- a/src/shared/js/utils/functions.js
+++ b/src/shared/js/utils/functions.js
@@ -372,7 +372,7 @@ async function pasteRich(rich, plain) {
  * @returns {void}
  * */
 export const copyHyperLinkToClipboard = (url, title) => {
-    const linkHtml = `<a href="${url}">${title}</a>`;
+    const linkHtml = `<a href="${escapeHtml(url)}">${escapeHtml(title)}</a>`;
     pasteRich(linkHtml, `${title} ${url}`);
 };
 
@@ -801,10 +801,12 @@ export const stringifyError = (e) => {
     return e.stack
         .split("\n")
         .map((line) =>
-            line
-                .split(" ")
-                .map((word) => word.split(extId).last())
-                .join(" "),
+            escapeHtml(
+                line
+                    .split(" ")
+                    .map((word) => word.split(extId).last())
+                    .join(" "),
+            ),
         )
         .join("<br/>");
 };

--- a/src/shared/js/utils/functions.js
+++ b/src/shared/js/utils/functions.js
@@ -10,6 +10,21 @@ import { LOGTRACE } from "@pmu/logTrace.js";
 import { val, hasClass, findEl } from "@pmu/miniquery.js";
 
 /**
+ * Escapes HTML special characters to prevent XSS when inserting into HTML.
+ * @param {string} str The string to escape
+ * @returns {string} The escaped string
+ */
+export const escapeHtml = (str) => {
+    if (typeof str !== "string") return String(str ?? "");
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+};
+
+/**
  * Generate a random integer between 0 and max
  * @param {number} max The maximum value of the random integer
  * @returns {number} The random integer

--- a/src/shared/js/utils/paper.js
+++ b/src/shared/js/utils/paper.js
@@ -441,11 +441,9 @@ export const mergePapers = (options = { newPaper: {}, oldPaper: {} }) => {
         if (newPaper.lastOpenDate > oldPaper.lastOpenDate) {
             mergedPaper.lastOpenDate = newPaper.lastOpenDate;
         }
-        mergedPaper.addDate = newPaper.addDate;
         // keep oldest add date
-        if (newPaper.addDate > oldPaper.addDate) {
-            mergedPaper.addDate = newPaper.addDate;
-        }
+        mergedPaper.addDate =
+            newPaper.addDate < oldPaper.addDate ? newPaper.addDate : oldPaper.addDate;
     }
     for (const attribute of opts.overwrites) {
         if (newPaper.hasOwnProperty(attribute)) {
@@ -477,7 +475,12 @@ export const addOrUpdatePaper = async ({
     prefs,
     tab,
     store = true,
-    contentScriptCallbacks = { update: () => {}, preprints: () => {}, feedback: null },
+    contentScriptCallbacks = {
+        update: () => {},
+        preprints: () => {},
+        done: () => {},
+        feedback: null,
+    },
 }) => {
     // start time
     const aouStart = Date.now();

--- a/src/shared/js/utils/parsers.js
+++ b/src/shared/js/utils/parsers.js
@@ -173,11 +173,11 @@ export const extractAuthor = (bibtex) =>
 
 export const extractCrossrefData = (crossrefResponse) => {
     if (!crossrefResponse.status || crossrefResponse.status !== "ok") {
-        error("Cannot parse CrossRef response", crossrefResponse);
+        logError("Cannot parse CrossRef response", crossrefResponse);
         return;
     }
     if (crossrefResponse["message-type"] !== "work") {
-        error("Unknown `message-type` from CrossRef", crossrefResponse);
+        logError("Unknown `message-type` from CrossRef", crossrefResponse);
         return;
     }
 
@@ -193,14 +193,14 @@ export const extractCrossrefData = (crossrefResponse) => {
           : null;
 
     if (!year) {
-        error("Cannot find year in CrossRef data", data);
+        logError("Cannot find year in CrossRef data", data);
         return;
     }
 
     const title = data.title[0];
 
     if (!title) {
-        error("Cannot find title in CrossRef data", data);
+        logError("Cannot find title in CrossRef data", data);
         return;
     }
 

--- a/src/shared/js/utils/parsers.js
+++ b/src/shared/js/utils/parsers.js
@@ -1924,12 +1924,22 @@ export const autoTagPaper = async (paper) => {
             if (!at.tags?.length) continue;
             if (!at.title && !at.author) continue;
 
-            const titleMatch = at.title
-                ? new RegExp(at.title, "i").test(paper.title)
-                : true;
-            const authorMatch = at.author
-                ? new RegExp(at.author, "i").test(paper.author)
-                : true;
+            let titleMatch = true;
+            let authorMatch = true;
+            try {
+                if (at.title) {
+                    titleMatch = paper.title
+                        .toLowerCase()
+                        .includes(at.title.toLowerCase());
+                }
+                if (at.author) {
+                    authorMatch = paper.author
+                        .toLowerCase()
+                        .includes(at.author.toLowerCase());
+                }
+            } catch (e) {
+                continue;
+            }
 
             if (titleMatch && authorMatch) {
                 at.tags.forEach((t) => tags.add(t));

--- a/src/shared/js/utils/parsers.js
+++ b/src/shared/js/utils/parsers.js
@@ -1928,14 +1928,10 @@ export const autoTagPaper = async (paper) => {
             let authorMatch = true;
             try {
                 if (at.title) {
-                    titleMatch = paper.title
-                        .toLowerCase()
-                        .includes(at.title.toLowerCase());
+                    titleMatch = new RegExp(at.title, "i").test(paper.title);
                 }
                 if (at.author) {
-                    authorMatch = paper.author
-                        .toLowerCase()
-                        .includes(at.author.toLowerCase());
+                    authorMatch = new RegExp(at.author, "i").test(paper.author);
                 }
             } catch (e) {
                 continue;


### PR DESCRIPTION
## TL;DR

Fix a collection of bugs (scoping, logic, infinite loops) and harden the extension against XSS by escaping all user-controlled data injected into HTML via a new `escapeHtml` utility.

## Breaking changes 🔥

None.

## Changes

- **XSS hardening**: Add `escapeHtml()` utility and apply it across all `innerHTML`/template-literal injection points in popup templates, options page, content script, bib matcher, and shared utils. Covers paper titles, authors, tags, notes, code links, venue names, URLs, and error messages.
- **Download sanitization**: Replace ad-hoc character stripping with a proper filename sanitizer (reserved chars, control chars, path traversal, length limit) and validate `pdfUrl` is `https?://` before downloading.
- **Sender validation**: Reject `chrome.runtime.onMessage` messages not originating from the extension itself.
- **PAT redaction**: Stop logging the GitHub Personal Access Token in plaintext; log `[REDACTED]` instead.
- **Code injection → func API**: Replace `chrome.scripting.executeScript({ code: ... })` with the safer `{ func, args }` form (MV3-compatible).
- **Infinite loop fix**: Bound the PDF title-setting loop (`makeTitle`) with a local iteration counter instead of the uncapped `while(1)`.
- **Bug fixes**: Fix `Array.prototype.last` mutating the original array via `.reverse()`; fix `mergePapers` keeping the newer `addDate` instead of the oldest; fix `prepareOverwriteData` `.map()` destructuring; fix implicit globals (`major`, `minor`, `pwcMatch`, `abstractH2`); fix OpenReview regex capturing only the last character; remove dead code after early `return` in `fetchPWCData`; add missing `done` callback default in `addOrUpdatePaper`; replace undefined `error()` calls with `logError()` in parsers; add null guards on OpenReview URL regex matches.
- **autoTag regex safety**: Wrap user-provided regex in try/catch to prevent crashes on invalid patterns while preserving regex matching behavior.

## Review hints

- `escapeHtml` in `src/shared/js/utils/functions.js` is the central utility — verify it covers the five OWASP-recommended characters (`& < > " '`).
- The `cutAuthors(escapeHtml(paper.author))` call order in `templates.js` means entity-encoded strings are measured for truncation length — acceptable tradeoff but worth noting.
- The `autoTagPaper` change in `parsers.js` keeps `new RegExp()` with a try/catch instead of switching to `.includes()`, preserving regex UX as documented in the options UI.
- The `sender.id` check in `background.js` silently drops external messages — callers get `undefined` responses, which existing code handles.
